### PR TITLE
fix: dockerfile usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,5 @@ COPY --from=build-env /src/main /usr/bin/local-sequencer
 
 EXPOSE 50051
 
-CMD ["local-sequencer", "-listen-all"]
+ENTRYPOINT ["local-sequencer"]
+CMD ["-listen-all"]

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,17 @@ pkgs := $(shell go list ./...)
 run := .
 count := 1
 
-## build: Build local-da binary.
+## build: Build local-sequencer binary.
 build:
 	@echo "--> Building local-sequencer"
 	@go build -o build/ ${LDFLAGS} ./...
 .PHONY: build
+
+## docker-build: Build local-sequencer docker image.
+docker-build:
+	@echo "--> Building local-sequencer docker image"
+	@docker build -t local-sequencer .
+.PHONY: docker-build
 
 ## help: Show this help message
 help: Makefile

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ make lint
 
 ## Local Sequencer
 
-In this repo there is a mock `local-sequencer` server that implements the `go-sequencing` interface. This server is useful for testing and development purposes.
+In this repo there is a mock `local-sequencer` server that implements the
+`go-sequencing` interface. This server is useful for testing and development
+purposes.
 
 ### Running the local sequencer binary
 
@@ -72,7 +74,7 @@ This will build the `local-sequencer` binary. To run the server, run:
 ./build/local-sequencer
 ```
 
-You will see an output like the following: 
+You will see an output like the following:
   
 ```sh
 2024/11/13 10:56:01 Listening on: localhost:50051
@@ -92,7 +94,8 @@ This will build a `local-sequencer` Docker image. To run the server, run:
 docker run -p 50051:50051 --rm local-sequencer
 ```
 
-In order to connect your rollup to your local sequencer, you need to pass in the rollup ID by using the following command:
+In order to connect your rollup to your local sequencer, you need to pass in the
+rollup ID by using the following command:
 
 ```sh
 docker run -p 50051:50051 --rm local-sequencer -listen-all -rollup-id=testing

--- a/README.md
+++ b/README.md
@@ -54,6 +54,50 @@ make test
 make lint
 ```
 
+## Local Sequencer
+
+In this repo there is a mock `local-sequencer` server that implements the `go-sequencing` interface. This server is useful for testing and development purposes.
+
+### Running the local sequencer binary
+
+To run the mock `local-sequencer` server, run the following command:
+
+```sh
+make build
+```
+
+This will build the `local-sequencer` binary. To run the server, run:
+
+```sh
+./build/local-sequencer
+```
+
+You will see an output like the following: 
+  
+```sh
+2024/11/13 10:56:01 Listening on: localhost:50051
+```
+
+### Running the local sequencer in Docker
+
+To run the mock `local-sequencer` server in Docker, run the following command:
+
+```sh
+make docker-build
+```
+
+This will build a `local-sequencer` Docker image. To run the server, run:
+
+```sh
+docker run -p 50051:50051 --rm local-sequencer
+```
+
+In order to connect your rollup to your local sequencer, you need to pass in the rollup ID by using the following command:
+
+```sh
+docker run -p 50051:50051 --rm local-sequencer -listen-all -rollup-id=testing
+```
+
 ## Contributing
 
 We welcome your contributions! Everyone is welcome to contribute, whether it's


### PR DESCRIPTION
Add docker-build Makefile command.
Add usage instructions for binary and docker to README. Add ENTRYPOINT to dockerfile to enable handing of additional flags easier.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `docker-build` target in the Makefile for building a Docker image for the local-sequencer.
	- Added a section in the README detailing the implementation and usage of the local-sequencer server, including build and run instructions.

- **Bug Fixes**
	- Updated the CMD and ENTRYPOINT instructions in the Dockerfile to improve execution behavior of the local-sequencer.

- **Documentation**
	- Enhanced README with instructions for building and running the local-sequencer both as a binary and within a Docker container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->